### PR TITLE
Fix: rename .xcresult folder to valid name for artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,18 @@ jobs:
             exit 1
           fi
 
+      - name: Rename test results folder (avoid dot in artifact name)
+        run: mv testResults/TestResults.xcresult testResults/TestResultsBundle
+
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results
-          path: testResults/TestResults.xcresult
+          path: testResults/TestResultsBundle
 
       - name: Process Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: testResults/TestResults.xcresult
+          path: testResults/TestResultsBundle
         if: success() || failure()


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to fix an artifact upload error caused by an invalid folder name (`.xcresult`).

✅ Changes:
- Renames `TestResults.xcresult` to `TestResultsBundle` (avoids dot in folder name)
- Updates all references to use the new folder name
- Ensures test results can be uploaded and processed without error

This allows the `xcresulttool` action to complete successfully and CI to pass.