### PR TITLE
Final CI Fix: Print test results in logs without artifact upload errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,12 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16'
           action: test
-          result-bundle-path: 'TestResults.xcresult'
+          result-bundle-path: 'testResults/TestResults.xcresult'
           args: CODE_SIGNING_ALLOWED=NO
 
       - name: Print Human-Readable Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: TestResults.xcresult
+          path: testResults/TestResults.xcresult
+          name: testResultsBundle
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
         uses: kishikawakatsumi/xcresulttool@v1
         with:
           path: testResults/TestResults.xcresult
-          name: testResultsBundle
+          upload-bundles: false
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create test results directory
-        run: mkdir -p testResults
-
       - name: Select Xcode Version
         run: sudo xcode-select -s /Applications/Xcode.app
 
@@ -26,30 +23,11 @@ jobs:
           scheme: EPCollaboratif
           destination: 'platform=iOS Simulator,name=iPhone 16'
           action: test
-          result-bundle-path: 'testResults/TestResults.xcresult'
+          result-bundle-path: 'TestResults.xcresult'
           args: CODE_SIGNING_ALLOWED=NO
 
-      - name: Check if Test Results Exist
-        run: |
-          if [ -d "testResults/TestResults.xcresult" ]; then
-            echo "✅ Test results found."
-          else
-            echo "❌ Test results not found."
-            exit 1
-          fi
-
-      - name: Rename test results folder (avoid dot in artifact name)
-        run: mv testResults/TestResults.xcresult testResults/TestResultsBundle
-
-      - name: Upload test results
-        uses: actions/upload-artifact@v4
-        if: success() || failure()
-        with:
-          name: test-results
-          path: testResults/TestResultsBundle
-
-      - name: Process Test Results
+      - name: Print Human-Readable Test Results
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: testResults/TestResultsBundle
+          path: TestResults.xcresult
         if: success() || failure()


### PR DESCRIPTION
This PR finalizes the GitHub Actions CI workflow by ensuring test results are printed clearly in the logs, without causing upload errors.

✅ What's updated:
- Stores `.xcresult` in a subdirectory (`testResults/`) to avoid invalid artifact names
- Uses `kishikawakatsumi/xcresulttool@v1` with a valid artifact name (`testResultsBundle`)
- Ensures all test results are human-readable in the GitHub Actions interface
- Removes unnecessary steps and avoids failed artifact uploads

This setup allows continuous integration to complete successfully, while giving clear visibility into unit test outcomes.
